### PR TITLE
update synctarget with registeredcluster labels

### DIFF
--- a/controllers/cluster-registration/suite_test.go
+++ b/controllers/cluster-registration/suite_test.go
@@ -388,7 +388,7 @@ var _ = Describe("Process registeredCluster: ", func() {
 				klog.Infof("getting synctarget in location workspace %s", test.AbsoluteLocationWorkspace)
 				labels := RegisteredClusterNamelabel + "=" + registeredCluster.Name + "," + RegisteredClusterNamespacelabel + "=" + registeredCluster.Namespace + "," + RegisteredClusterWorkspace + "=" + strings.ReplaceAll(registeredCluster.Annotations["clusterName"], ":", "-") + "," + RegisteredClusterUidLabel + "=" + string(registeredCluster.UID)
 
-				syncTargetList, err := virtualWorkspaceDynamicClient.Resource(clusterGVR).List(locationContext, metav1.ListOptions{
+				syncTargetList, err := virtualWorkspaceDynamicClient.Resource(syncTargetGVR).List(locationContext, metav1.ListOptions{
 					LabelSelector: labels,
 				})
 				if err != nil {


### PR DESCRIPTION
Copy RegisteredCluster labels to SyncTargets
Update SyncTarget when labels have changed
Maintain the existing labels on SyncTarget

https://issues.redhat.com/browse/CMCS-140

Signed-off-by: Robin Y Bobbitt <rbobbitt@redhat.com>