### PR TITLE
fix SKIP_WEBHOOK configmap env var

### DIFF
--- a/config/installer/installer.yaml
+++ b/config/installer/installer.yaml
@@ -61,7 +61,7 @@ spec:
           valueFrom:
             configMapKeyRef:
               name: installer-config
-              key: IMAGE
+              key: SKIP_WEBHOOK
         image: controller:latest
         livenessProbe:
           httpGet:

--- a/controllers/installer/installer_controller.go
+++ b/controllers/installer/installer_controller.go
@@ -176,9 +176,12 @@ func (r *ClusterRegistrarReconciler) processClusterRegistrarCreation(ctx context
 	}
 
 	//Deploy webhook
+	r.Log.Info("checking SKIP_WEBHOOK", "SKIP_WEBHOOK", os.Getenv("SKIP_WEBHOOK"))
 	if os.Getenv("SKIP_WEBHOOK") != "true" {
+		r.Log.Info("deploying webhook")
 		return r.deployWebhook(ctx, applier, readerDeploy, values)
 	} else {
+		r.Log.Info("skipping webhook deployment")
 		return nil
 	}
 }


### PR DESCRIPTION
Signed-off-by: Robin Y Bobbitt <rbobbitt@redhat.com>

Confirmed running `make deploy` I see:
```
I0809 18:54:57.037866       1 installer_controller.go:112] "controllers/Installer: Running Reconcile for Cluster Registrar" name="cluster-reg"
I0809 18:54:57.056069       1 installer_controller.go:141] "controllers/Installer: processClusterRegistrarCreation" Name="cluster-reg"
I0809 18:54:57.114122       1 installer_controller.go:179] "controllers/Installer: checking SKIP_WEBHOOK" SKIP_WEBHOOK="false"
I0809 18:54:57.114146       1 installer_controller.go:181] "controllers/Installer: deploying webhook"
```