### PR TITLE
create clusterrole and clusterrolebinding for syncer service account

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ ifeq (, $(shell kubectl plugin list 2>/dev/null | grep kubectl-kcp))
 		cd $$KCP_TMP_DIR ;\
 		git clone https://github.com/kcp-dev/kcp.git ;\
 		cd kcp ;\
-		git checkout v0.7.0; \
+		git checkout v0.7.1; \
 		make install WHAT="./cmd/kubectl-kcp"; \
 		make install WHAT="./cmd/kcp"; \
 	)
@@ -339,7 +339,10 @@ samples: applier
 	               --values resources/compute-templates/hack-values.yaml --output-file hack/compute/namespace.yaml
 	applier render --paths resources/compute-templates/virtual-workspace/service_account.yaml \
 	               --values resources/compute-templates/hack-values.yaml --output-file hack/compute/service_account.yaml
-	
+	applier render --paths resources/compute-templates/virtual-workspace/role_binding.yaml \
+	               --values resources/compute-templates/hack-values.yaml --output-file hack/compute/role_binding.yaml
+	applier render --paths resources/compute-templates/virtual-workspace/apiexport.yaml \
+	               --values resources/compute-templates/hack-values.yaml --output-file hack/compute/apiexport.yaml
 
 # Generate code
 generate: kubebuilder-tools controller-gen register-gen

--- a/controllers/cluster-registration/suite_test.go
+++ b/controllers/cluster-registration/suite_test.go
@@ -431,8 +431,14 @@ var _ = Describe("Process registeredCluster: ", func() {
 			Eventually(func() error {
 				for _, locationWorkspace := range registeredCluster.Spec.Location {
 					locationContext := logicalcluster.WithCluster(computeContext, logicalcluster.New(locationWorkspace))
-					klog.Infof("getting service account %s in workspace %s", helpers.GetSyncerServiceAccountName(), locationWorkspace)
-					_, err := apiExportVirtualWorkspaceKubeClient.CoreV1().ServiceAccounts("default").Get(locationContext, helpers.GetSyncerServiceAccountName(), metav1.GetOptions{})
+
+					syncTarget, err := getSyncTarget(locationContext, registeredCluster)
+					if err != nil {
+						klog.Errorf("failed getting sync target %s", err)
+						return err
+					}
+					klog.Infof("getting service account %s in workspace %s", helpers.GetSyncerName(syncTarget), locationWorkspace)
+					_, err = apiExportVirtualWorkspaceKubeClient.CoreV1().ServiceAccounts("default").Get(locationContext, helpers.GetSyncerName(syncTarget), metav1.GetOptions{})
 					if err != nil {
 						klog.Errorf("failed getting service account %s", err)
 						return err

--- a/hack/compute/apibinding.yaml
+++ b/hack/compute/apibinding.yaml
@@ -15,10 +15,10 @@ spec:
   - group: ""
     resource: serviceaccounts
   - group: workload.kcp.dev
-    identityHash: <identityHash>
     resource: synctargets
-  # - group: "rbac.authorization.k8s.io"
-  #   resource: clusterroles
-  # - group: "rbac.authorization.k8s.io"
-  #   resource: clusterrolebindings
+    identityHash: <identityHash>
+  - group: "rbac.authorization.k8s.io"
+    resource: clusterroles
+  - group: "rbac.authorization.k8s.io"
+    resource: clusterrolebindings
 ---

--- a/hack/compute/apiexport.yaml
+++ b/hack/compute/apiexport.yaml
@@ -10,12 +10,14 @@ spec:
     resource: secrets
   - group: ""
     resource: serviceaccounts
-  # - group: "rbac.authorization.k8s.io"
-  #   resource: clusterroles
-  # - group: "rbac.authorization.k8s.io"
-  #   resource: clusterrolebindings
   - group: workload.kcp.dev
     resource: synctargets
     identityHash: <identityHash>
+  - group: "rbac.authorization.k8s.io"
+    resource: clusterroles
+  - group: "rbac.authorization.k8s.io"
+    resource: clusterrolebindings
   latestResourceSchemas:
   - latest.registeredclusters.singapore.open-cluster-management.io
+
+---

--- a/pkg/helpers/workspace.go
+++ b/pkg/helpers/workspace.go
@@ -28,7 +28,3 @@ func GetSyncerName(syncTarget *unstructured.Unstructured) string { // Should be 
 	base36hash := strings.ToLower(base36.EncodeBytes(syncerHash[:]))
 	return fmt.Sprintf("%s-%s-%s", GetSyncerPrefix(), syncTarget.GetName(), base36hash[:8])
 }
-
-func GetSyncerServiceAccountName() string {
-	return "kcp-syncer-sa"
-}

--- a/resources/compute-templates/virtual-workspace/apiexport.yaml
+++ b/resources/compute-templates/virtual-workspace/apiexport.yaml
@@ -13,9 +13,9 @@ spec:
   - group: workload.kcp.dev
     resource: synctargets
     identityHash: {{ .IdentityHash }}
-  # - group: "rbac.authorization.k8s.io"
-  #   resource: clusterroles
-  # - group: "rbac.authorization.k8s.io"
-  #   resource: clusterrolebindings
+  - group: "rbac.authorization.k8s.io"
+    resource: clusterroles
+  - group: "rbac.authorization.k8s.io"
+    resource: clusterrolebindings
   latestResourceSchemas:
   - latest.registeredclusters.singapore.open-cluster-management.io

--- a/resources/compute-templates/workspace/apibinding.yaml
+++ b/resources/compute-templates/workspace/apibinding.yaml
@@ -17,7 +17,7 @@ spec:
   - group: workload.kcp.dev
     resource: synctargets
     identityHash: {{ .IdentityHash }}
-  # - group: "rbac.authorization.k8s.io"
-  #   resource: clusterroles
-  # - group: "rbac.authorization.k8s.io"
-  #   resource: clusterrolebindings
+  - group: "rbac.authorization.k8s.io"
+    resource: clusterroles
+  - group: "rbac.authorization.k8s.io"
+    resource: clusterrolebindings


### PR DESCRIPTION
Signed-off-by: Robin Y Bobbitt <rbobbitt@redhat.com>

Create clusterrole and clusterrolebinding for syncer service account. Create service account per syncer, owned by the SyncTarget, to match kcp behavior.