### PR TITLE
add sync-target-uid arg to syncer deployment

### DIFF
--- a/resources/cluster-registration/kcp_syncer_manifestwork.yaml
+++ b/resources/cluster-registration/kcp_syncer_manifestwork.yaml
@@ -119,6 +119,7 @@ spec:
               - /ko-app/syncer
               args:
               - "--sync-target-name={{ .SyncTargetName }}"
+              - "--sync-target-name={{ .SyncTargetUid }}"
               - "--from_cluster={{ .LogicalCluster }}"
               - --from-kubeconfig=/kcp/kubeconfig
               - --resources=configmaps


### PR DESCRIPTION
Signed-off-by: Robin Y Bobbitt <rbobbitt@redhat.com>

Adds sync-target-uid arg to syncer deployment that was introduced in kcp 0.7.0.
Adds a "joined" check around all syncer-related logic to ensure we don't try to create syncer service account before we create synctarget.