### PR TITLE
fix version number used by quay image - use variable that ACM main to…

### DIFF
--- a/test/e2e/install-compute-operator.sh
+++ b/test/e2e/install-compute-operator.sh
@@ -8,7 +8,7 @@ echo "--- Install the compute operator ..."
 
 cd ${COMPUTE_OPERATOR_DIR}
 
-export IMG="quay.io/stolostron/compute-operator:2.7.0-PR${PULL_NUMBER}-${PULL_PULL_SHA}"
+export IMG="quay.io/stolostron/compute-operator:${release}-PR${PULL_NUMBER}-${PULL_PULL_SHA}"
 echo "--- Quay image is ${IMG}"
 
 echo "--- Check namespace - before"


### PR DESCRIPTION
…oling is using

Signed-off-by: Chris Ahl <cahl@redhat.com>

Hopefully this will keep us from having to update the hard coded value when the ACM release changes in main branch tooling 